### PR TITLE
svc/back; config 관리 제외 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+## application.properties 제외 ##
+src/main/resources/application.properties


### PR DESCRIPTION
- application.properties 파일을 .gitignore에 추가
- 비밀번호 같은 민감한 정보 보호를 위해 git 추적에서 제외